### PR TITLE
Fix upgrade process

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -24,7 +24,7 @@ ynh_script_progression "Upgrading source files..."
 
 # Upgrade documentation: https://docs.espocrm.com/administration/upgrading-manually/
 ynh_setup_source --dest_dir="$install_dir" --full_replace --keep="data custom client/custom"
-ynh_exec_as_app bin/command migrate
+ynh_exec_as_app $install_dir/bin/command migrate
 
 #=================================================
 # UPDATE A CONFIG FILE

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -24,7 +24,7 @@ ynh_script_progression "Upgrading source files..."
 
 # Upgrade documentation: https://docs.espocrm.com/administration/upgrading-manually/
 ynh_setup_source --dest_dir="$install_dir" --full_replace --keep="data custom client/custom"
-ynh_exec_as_app chmod 754 $install_dir/bin/command
+chmod 754 $install_dir/bin/command
 ynh_exec_as_app $install_dir/bin/command migrate
 
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -24,6 +24,7 @@ ynh_script_progression "Upgrading source files..."
 
 # Upgrade documentation: https://docs.espocrm.com/administration/upgrading-manually/
 ynh_setup_source --dest_dir="$install_dir" --full_replace --keep="data custom client/custom"
+ynh_exec_as_app chmod 754 $install_dir/bin/command
 ynh_exec_as_app $install_dir/bin/command migrate
 
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -22,7 +22,9 @@ ynh_app_setting_set_default --key=php_memory_limit --value=256M
 #=================================================
 ynh_script_progression "Upgrading source files..."
 
-ynh_setup_source --dest_dir="$install_dir" --full_replace --keep="data/config.php"
+# Upgrade documentation: https://docs.espocrm.com/administration/upgrading-manually/
+ynh_setup_source --dest_dir="$install_dir" --full_replace --keep="data custom client/custom"
+ynh_exec_as_app bin/command migrate
 
 #=================================================
 # UPDATE A CONFIG FILE


### PR DESCRIPTION
I tried to upgrade my productive EspoCRM installation and ran into issues. #25 

Then, I researched Yunohost packaging and EspoCRM manual upgrade topics.

[EspoCRM documentation](https://docs.espocrm.com/administration/upgrading-manually/#1-replace-files) says we need to keep:
- `data`
- `custom`
- `client/custom`

Right below, it says we need to run the command:
`bin/command migrate`

And because in my first attempt the command failed with message _permission denied_, I add the permission grand as described [here in the documentation](https://docs.espocrm.com/administration/server-configuration/#required-permissions-for-unix-based-systems).

With this Pull Request I address all these issues, and the upgrade process went well on my productive installation. (I manually upgraded my installation with `sudo yunohost app upgrade espocrm -u https://github.com/baartch/espocrm_ynh`)

Here is my successful upgrade log: https://paste.yunohost.org/raw/bunokuqoto
<img width="1703" height="638" alt="image" src="https://github.com/user-attachments/assets/9969d1f8-62e0-470a-87b9-960fcfe3d61c" />
